### PR TITLE
feat: add GameDetails component

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     }
   },
   "dependencies": {
+    "@styled-icons/fa-brands": "^10.26.0",
     "@styled-icons/material-outlined": "^10.28.0",
     "@styled-icons/remix-fill": "^10.18.0",
     "next": "10.0.3",

--- a/src/components/GameDetails/data.mock.ts
+++ b/src/components/GameDetails/data.mock.ts
@@ -1,0 +1,8 @@
+export default {
+  developer: 'Different Tales',
+  releaseDate: '2020-11-21T23:00:00',
+  platforms: ['windows', 'linux', 'mac'],
+  publisher: 'Walkabout',
+  rating: 'BR0',
+  genres: ['Role-playing']
+}

--- a/src/components/GameDetails/index.stories.tsx
+++ b/src/components/GameDetails/index.stories.tsx
@@ -1,0 +1,32 @@
+import { Story, Meta } from '@storybook/react/types-6-0'
+
+import GameDetails, { GameDetailsProps } from '.'
+import mockGame from './data.mock'
+
+export default {
+  title: 'Game/GameDetails',
+  component: GameDetails,
+  parameters: {
+    backgrounds: {
+      default: 'won-dark'
+    }
+  },
+  args: mockGame,
+  argTypes: {
+    releaseDate: {
+      control: 'date'
+    },
+    platforms: {
+      control: {
+        type: 'inline-check',
+        options: ['windows', 'linux', 'mac']
+      }
+    }
+  }
+} as Meta
+
+export const Default: Story<GameDetailsProps> = (args) => (
+  <div style={{ maxWidth: '130rem', margin: '0 auto' }}>
+    <GameDetails {...args} />
+  </div>
+)

--- a/src/components/GameDetails/index.test.tsx
+++ b/src/components/GameDetails/index.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithTheme } from 'utils/tests/helpers'
+
+import GameDetails, { GameDetailsProps } from '.'
+
+const props: GameDetailsProps = {
+  developer: 'Developer',
+  platforms: ['windows', 'linux', 'mac'],
+  releaseDate: '2020-11-21T23:00:00',
+  publisher: 'Publisher',
+  rating: 'BR0',
+  genres: ['Action', 'Adventure']
+}
+
+describe('<GameDetails />', () => {
+  it('should render the blocks', () => {
+    renderWithTheme(<GameDetails {...props} />)
+
+    expect(
+      screen.getByRole('heading', { name: /Developer/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Release Date/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Platforms/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Publisher/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Rating/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Genres/i })).toBeInTheDocument()
+  })
+
+  it('should render platforms icons', () => {
+    renderWithTheme(<GameDetails {...props} />)
+
+    expect(screen.getByRole('img', { name: /Linux/i })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /Windows/i })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /Mac/i })).toBeInTheDocument()
+  })
+
+  it('should render the formatted date', () => {
+    renderWithTheme(<GameDetails {...props} />)
+
+    expect(screen.getByText('Nov 21, 2020')).toBeInTheDocument()
+  })
+
+  it('should render FREE when BR0', () => {
+    renderWithTheme(<GameDetails {...props} />)
+
+    expect(screen.getByText(/free/i)).toBeInTheDocument()
+  })
+
+  it('should render 18+ when BR18', () => {
+    renderWithTheme(<GameDetails {...props} rating="BR18" />)
+
+    expect(screen.getByText(/18\+/)).toBeInTheDocument()
+  })
+
+  it('should render a list of genres', () => {
+    renderWithTheme(<GameDetails {...props} />)
+
+    expect(screen.getByText('Action / Adventure')).toBeInTheDocument()
+  })
+})

--- a/src/components/GameDetails/index.tsx
+++ b/src/components/GameDetails/index.tsx
@@ -1,0 +1,89 @@
+import { Apple, Linux, Windows } from '@styled-icons/fa-brands'
+
+import Heading from 'components/Heading'
+import MediaMatch from 'components/MediaMatch'
+
+import * as S from './styles'
+
+type Platform = 'windows' | 'linux' | 'mac'
+type Rating = 'BR0' | 'BR10' | 'BR12' | 'BR14' | 'BR16' | 'BR18'
+
+export type GameDetailsProps = {
+  developer: string
+  releaseDate: string
+  platforms: Platform[]
+  publisher: string
+  rating: Rating
+  genres: string[]
+}
+
+const GameDetails = ({
+  developer,
+  platforms,
+  publisher,
+  releaseDate,
+  rating,
+  genres
+}: GameDetailsProps) => {
+  const platformIcons = {
+    linux: <Linux title="Linux" size={18} />,
+    mac: <Apple title="Mac" size={18} />,
+    windows: <Windows title="Windows" size={18} />
+  }
+
+  return (
+    <S.Container>
+      <MediaMatch greaterThan="small">
+        <Heading lineLeft lineColor="secondary">
+          Game Details
+        </Heading>
+      </MediaMatch>
+
+      <S.Content>
+        <S.Block>
+          <S.Label>Developer</S.Label>
+          <S.Description>{developer}</S.Description>
+        </S.Block>
+
+        <S.Block>
+          <S.Label>Release Date</S.Label>
+          <S.Description>
+            {new Intl.DateTimeFormat('en-US', {
+              day: 'numeric',
+              month: 'short',
+              year: 'numeric'
+            }).format(new Date(releaseDate))}
+          </S.Description>
+        </S.Block>
+
+        <S.Block>
+          <S.Label>Platforms</S.Label>
+          <S.IconsWrapper>
+            {platforms.map((icon: Platform) => (
+              <S.Icon key={icon}>{platformIcons[icon]}</S.Icon>
+            ))}
+          </S.IconsWrapper>
+        </S.Block>
+
+        <S.Block>
+          <S.Label>Publisher</S.Label>
+          <S.Description>{publisher}</S.Description>
+        </S.Block>
+
+        <S.Block>
+          <S.Label>Rating</S.Label>
+          <S.Description>
+            {rating === 'BR0' ? 'FREE' : `${rating.replace('BR', '')}+`}
+          </S.Description>
+        </S.Block>
+
+        <S.Block>
+          <S.Label>Genres</S.Label>
+          <S.Description>{genres.join(' / ')}</S.Description>
+        </S.Block>
+      </S.Content>
+    </S.Container>
+  )
+}
+
+export default GameDetails

--- a/src/components/GameDetails/styles.ts
+++ b/src/components/GameDetails/styles.ts
@@ -1,0 +1,55 @@
+import styled, { css } from 'styled-components'
+import media from 'styled-media-query'
+
+export const Container = styled.div`
+  ${({ theme }) => css`
+    margin: ${theme.spacings.small} 0;
+  `}
+`
+
+export const Content = styled.div`
+  ${({ theme }) => css`
+    display: grid;
+    gap: ${theme.spacings.xsmall};
+    grid-template-columns: repeat(2, 1fr);
+    margin-top: ${theme.spacings.small};
+
+    ${media.greaterThan('medium')`
+      grid-template-columns: repeat(3, 1fr);
+    `}
+
+    ${media.greaterThan('large')`
+    grid-template-columns: repeat(6, 1fr);
+    `}
+  `}
+`
+
+export const Block = styled.div``
+
+export const Label = styled.h3`
+  ${({ theme }) => css`
+    font-size: ${theme.font.sizes.small};
+    font-weight: ${theme.font.light};
+    color: ${theme.colors.white};
+  `}
+`
+
+export const Description = styled.p`
+  ${({ theme }) => css`
+    font-size: ${theme.font.sizes.medium};
+    font-weight: ${theme.font.bold};
+    color: ${theme.colors.white};
+  `}
+`
+
+export const IconsWrapper = styled.div`
+  ${({ theme }) => css`
+    color: ${theme.colors.white};
+  `}
+`
+
+export const Icon = styled.span`
+  ${({ theme }) => css`
+    margin-right: ${theme.spacings.xxsmall};
+  `}
+`

--- a/src/components/GameInfo/index.stories.tsx
+++ b/src/components/GameInfo/index.stories.tsx
@@ -4,7 +4,7 @@ import GameInfo, { GameInfoProps } from '.'
 import mockGame from './data.mock'
 
 export default {
-  title: 'GameInfo',
+  title: 'Game/GameInfo',
   component: GameInfo,
   parameters: {
     backgrounds: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,6 +2464,14 @@
     resolve-from "^5.0.0"
     store2 "^2.7.1"
 
+"@styled-icons/fa-brands@^10.26.0":
+  version "10.26.0"
+  resolved "https://registry.yarnpkg.com/@styled-icons/fa-brands/-/fa-brands-10.26.0.tgz#ca20250c86a23df87b9f21acfbe94fc5fa97d8f6"
+  integrity sha512-1J2Pac3QwxArDzI/EAibLlTQ+4mFr7e6ZIVdLT+hmQrTQ+2Ibm403fHwsEBvLYzCI/7XQERPcxy1uBdkSgrKXw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@styled-icons/styled-icon" "^10.6.0"
+
 "@styled-icons/material-outlined@^10.28.0":
   version "10.28.0"
   resolved "https://registry.yarnpkg.com/@styled-icons/material-outlined/-/material-outlined-10.28.0.tgz#57d34c7a417bb79cf930bf1302aa8b463de1bcad"


### PR DESCRIPTION
- Added GameDetails layout, styles, stories, and tests.
- Formatted date with Intl.
- Added platform icons from styled-icon/fa-brands
- Added storybook argTypes platforms option selection to avoid errors when rendering icons.
- Moved GameInfo to the storybook Game section.