### PR TITLE
feat: add Gallery component

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@storybook/react": "^6.1.11",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
-    "@testing-library/user-event": "^12.7.3",
+    "@testing-library/user-event": "^13.0.10",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.13",
     "@types/react": "^17.0.0",

--- a/src/components/Gallery/data.mock.ts
+++ b/src/components/Gallery/data.mock.ts
@@ -1,0 +1,26 @@
+export default [
+  {
+    src: '/img/games/cyberpunk-1.jpg',
+    label: 'Gallery Image 1'
+  },
+  {
+    src: '/img/games/cyberpunk-2.jpg',
+    label: 'Gallery Image 2'
+  },
+  {
+    src: '/img/games/cyberpunk-3.jpg',
+    label: 'Gallery Image 3'
+  },
+  {
+    src: '/img/games/cyberpunk-4.jpg',
+    label: 'Gallery Image 4'
+  },
+  {
+    src: '/img/games/cyberpunk-5.jpg',
+    label: 'Gallery Image 5'
+  },
+  {
+    src: '/img/games/cyberpunk-6.jpg',
+    label: 'Gallery Image 6'
+  }
+]

--- a/src/components/Gallery/index.stories.tsx
+++ b/src/components/Gallery/index.stories.tsx
@@ -1,0 +1,23 @@
+import { Story, Meta } from '@storybook/react/types-6-0'
+
+import Gallery, { GalleryProps } from '.'
+
+import items from './data.mock'
+
+export default {
+  title: 'Game/Gallery',
+  component: Gallery,
+  args: { items },
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: {
+      default: 'won-dark'
+    }
+  }
+} as Meta
+
+export const Default: Story<GalleryProps> = (args) => (
+  <div style={{ maxWidth: '130rem', margin: '0 auto' }}>
+    <Gallery {...args} />
+  </div>
+)

--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -1,0 +1,76 @@
+import 'matchMediaMock'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { renderWithTheme } from 'utils/tests/helpers'
+import mockItems from './data.mock'
+
+import Gallery from '.'
+
+describe('<Gallery />', () => {
+  it('should render thumbnails as buttons', () => {
+    renderWithTheme(<Gallery items={mockItems.slice(0, 2)} />)
+
+    expect(
+      screen.getByRole('button', { name: /Thumb - Gallery Image 1/i })
+    ).toHaveAttribute('src', mockItems[0].src)
+    expect(
+      screen.getByRole('button', { name: /Thumb - Gallery Image 2/i })
+    ).toHaveAttribute('src', mockItems[1].src)
+  })
+
+  it('should handle open modal', () => {
+    renderWithTheme(<Gallery items={mockItems.slice(0, 2)} />)
+
+    const modal = screen.getByLabelText('modal')
+
+    expect(modal.getAttribute('aria-hidden')).toBe('true')
+    expect(modal).toHaveStyle({ opacity: 0, pointerEvents: 'none' })
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Thumb - Gallery Image 1/i })
+    )
+
+    expect(modal.getAttribute('aria-hidden')).toBe('false')
+    expect(modal).toHaveStyle({ opacity: 1 })
+  })
+
+  it('should open modal with selected image', async () => {
+    renderWithTheme(<Gallery items={mockItems.slice(0, 2)} />)
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Thumb - Gallery Image 2/i })
+    )
+
+    const img = await screen.findByRole('img', { name: /Gallery Image 2/i })
+    expect(img.parentElement?.parentElement).toHaveClass('slick-active')
+  })
+
+  it('should handle close modal when overlay or button is clicked', () => {
+    renderWithTheme(<Gallery items={mockItems.slice(0, 2)} />)
+
+    const modal = screen.getByLabelText('modal')
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Thumb - Gallery Image 1/i })
+    )
+
+    userEvent.click(screen.getByRole('button', { name: /close modal/i }))
+    expect(modal.getAttribute('aria-hidden')).toBe('true')
+    expect(modal).toHaveStyle({ opacity: 0, pointerEvents: 'none' })
+  })
+
+  it('should handle close modal when ESC key is pressed', () => {
+    renderWithTheme(<Gallery items={mockItems.slice(0, 2)} />)
+
+    const modal = screen.getByLabelText('modal')
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Thumb - Gallery Image 1/i })
+    )
+
+    userEvent.keyboard('{esc}')
+    expect(modal.getAttribute('aria-hidden')).toBe('true')
+    expect(modal).toHaveStyle({ opacity: 0, pointerEvents: 'none' })
+  })
+})

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  ArrowBackIos as ArrowLeft,
+  ArrowForwardIos as ArrowRight,
+  Close
+} from '@styled-icons/material-outlined'
+import SlickSlider from 'react-slick'
+
+import Slider, { SliderSettings } from 'components/Slider'
+
+import * as S from './styles'
+
+const commonSettings: SliderSettings = {
+  arrows: true,
+  infinite: false,
+  lazyLoad: 'ondemand',
+  nextArrow: <ArrowRight aria-label="Next image" />,
+  prevArrow: <ArrowLeft aria-label="Previous image" />
+}
+
+const sliderSettings: SliderSettings = {
+  ...commonSettings,
+  slidesToShow: 4,
+  responsive: [
+    {
+      breakpoint: 1375,
+      settings: {
+        arrows: false,
+        slidesToShow: 3.2,
+        draggable: true
+      }
+    },
+    {
+      breakpoint: 1024,
+      settings: {
+        arrows: false,
+        slidesToShow: 2.2,
+        draggable: true
+      }
+    },
+    {
+      breakpoint: 768,
+      settings: {
+        arrows: false,
+        slidesToShow: 2.2,
+        draggable: true
+      }
+    }
+  ]
+}
+
+const modalSettings: SliderSettings = {
+  ...commonSettings,
+  slidesToShow: 1
+}
+
+export type GalleryImageProps = {
+  src: string
+  label: string
+}
+
+export type GalleryProps = {
+  items: GalleryImageProps[]
+}
+
+const Gallery = ({ items }: GalleryProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const slider = useRef<SlickSlider>(null)
+
+  useEffect(() => {
+    const handleKeyUp = ({ key }: KeyboardEvent) => {
+      key === 'Escape' && setIsOpen(false)
+    }
+
+    window.addEventListener('keyup', handleKeyUp)
+
+    return () => window.removeEventListener('keyup', handleKeyUp)
+  }, [])
+
+  return (
+    <S.Container>
+      <Slider ref={slider} settings={sliderSettings}>
+        {items.map((item, index) => (
+          <img
+            key={`thumb-${index}`}
+            role="button"
+            src={item.src}
+            alt={`Thumb - ${item.label}`}
+            onClick={() => {
+              setIsOpen(true)
+              slider.current!.slickGoTo(index, true)
+            }}
+          />
+        ))}
+      </Slider>
+
+      <S.Modal isOpen={isOpen} aria-label="modal" aria-hidden={!isOpen}>
+        <S.Close
+          role="button"
+          aria-label="close modal"
+          onClick={() => setIsOpen(false)}
+        >
+          <Close size={40} />
+        </S.Close>
+
+        <S.Content>
+          <Slider ref={slider} settings={modalSettings}>
+            {items.map((item, index) => (
+              <img
+                key={`gallery-${index}`}
+                src={item.src}
+                alt={`${item.label}`}
+              />
+            ))}
+          </Slider>
+        </S.Content>
+      </S.Modal>
+    </S.Container>
+  )
+}
+
+export default Gallery

--- a/src/components/Gallery/styles.ts
+++ b/src/components/Gallery/styles.ts
@@ -1,0 +1,95 @@
+import styled, { css } from 'styled-components'
+import media from 'styled-media-query'
+
+export const Container = styled.div`
+  ${({ theme }) => css`
+    .slick-prev,
+    .slick-next {
+      display: block;
+      width: 2.5rem;
+      height: 2.5rem;
+      padding: 0;
+      color: ${theme.colors.white};
+      cursor: pointer;
+      position: absolute;
+      top: 50%;
+      transform: translate(0, -50%);
+
+      &.slick-disabled {
+        visibility: hidden;
+      }
+    }
+
+    .slick-prev {
+      left: -${theme.spacings.xxlarge};
+    }
+
+    .slick-next {
+      right: -${theme.spacings.xxlarge};
+    }
+
+    .slick-slide > div {
+      margin: 0 ${theme.spacings.xsmall};
+      cursor: pointer;
+    }
+
+    .slick-list {
+      margin: 0 -${theme.spacings.xsmall};
+    }
+
+    ${media.lessThan('huge')`
+      overflow-x: hidden;
+    `}
+  `}
+`
+
+type ModalProps = {
+  isOpen: boolean
+}
+
+const modalModifiers = {
+  open: () => css`
+    opacity: 1;
+  `,
+
+  close: () => css`
+    opacity: 0;
+    pointer-events: none;
+  `
+}
+export const Modal = styled.div<ModalProps>`
+  ${({ theme, isOpen }) => css`
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: ${theme.layers.modal};
+    transition: opacity ${theme.transition.default};
+
+    ${isOpen && modalModifiers.open()}
+    ${!isOpen && modalModifiers.close()}
+  `}
+`
+
+export const Close = styled.div`
+  ${({ theme }) => css`
+    color: ${theme.colors.white};
+    position: absolute;
+    left: 0;
+    top: 0;
+    cursor: pointer;
+    width: 100%;
+    height: 100%;
+    text-align: right;
+  `}
+`
+
+export const Content = styled.div`
+  max-width: min(120rem, 100%);
+  max-height: 80rem;
+`

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react'
 import SlickSlider, { Settings } from 'react-slick'
 
 import * as S from './styles'
@@ -9,10 +10,15 @@ export type SliderProps = {
   settings: SliderSettings
 }
 
-const Slider = ({ children, settings }: SliderProps) => (
+const Slider: React.ForwardRefRenderFunction<SlickSlider, SliderProps> = (
+  { children, settings },
+  ref
+) => (
   <S.Wrapper>
-    <SlickSlider {...settings}>{children}</SlickSlider>
+    <SlickSlider ref={ref} {...settings}>
+      {children}
+    </SlickSlider>
   </S.Wrapper>
 )
 
-export default Slider
+export default forwardRef(Slider)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,10 +2540,10 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
-"@testing-library/user-event@^12.7.3":
-  version "12.7.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.7.3.tgz#ef674ccb91794e52123b3532c336485d16f453b3"
-  integrity sha512-IdSHkWfbeSSJRFlldvHDWfVX0U18TbXIvLSGII+JbqkJrsflFr4OWlQIua0TvcVVJNna3BNrNvRSvpQ0yvSXlA==
+"@testing-library/user-event@^13.0.10":
+  version "13.0.10"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.0.10.tgz#8bd5c9f82b5e707fde598a8f319943c289a87378"
+  integrity sha512-LORQD86zMtv/lP1RpulfBm5wGjTwmzqCRBx15nOYcH55ojsGoaTNsL76V5eoZWefl+T2SvG0kqY6mwOxJ1/5Og==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
Updated Slider component to forward ref to children.
Added modal to show selected slide.
Added implementation to close modal with ESC, click on the overlay or on the X on the right corner.
Updated testing-library/user-event to support userEvent.keyboard.