### PR TITLE
feat: create wish list page with Apollo cache

### DIFF
--- a/src/templates/Wishlist/index.test.tsx
+++ b/src/templates/Wishlist/index.test.tsx
@@ -6,9 +6,9 @@ import gamesMock from 'components/GameCardSlider/data.mock'
 import highlightMock from 'components/Highlight/data.mock'
 
 import Wishlist, { WhishlistTemplateProps } from '.'
+import { WishlistContextDefaultValues } from 'hooks/use-wishlist'
 
 const props: WhishlistTemplateProps = {
-  games: gamesMock,
   recommendedTitle: 'You may like these games',
   recommendedHighlight: highlightMock,
   recommendedGames: [gamesMock[0]]
@@ -32,25 +32,35 @@ jest.mock('components/Showcase', () => {
 
 describe('<Wishlist />', () => {
   it('should render the template with components', () => {
-    render(<Wishlist {...props} />)
+    const wishlistProviderProps = {
+      ...WishlistContextDefaultValues,
+      items: [gamesMock[0]]
+    }
+
+    render(<Wishlist {...props} />, { wishlistProviderProps })
 
     expect(
       screen.getByRole('heading', {
         name: /wishlist/i
       })
     ).toBeInTheDocument()
-    expect(screen.getAllByTestId('Mock Showcase')).toHaveLength(1)
-
-    expect(screen.getAllByText(/population zero/i)).toHaveLength(6)
+    expect(screen.getByTestId('Mock Showcase')).toBeInTheDocument()
+    expect(screen.getByText(/population zero/i)).toBeInTheDocument
   })
 
   it('should render empty when there are no games', () => {
+    const wishlistProviderProps = {
+      ...WishlistContextDefaultValues,
+      items: []
+    }
+
     render(
       <Wishlist
         recommendedTitle="You may like these games"
         recommendedGames={gamesMock}
         recommendedHighlight={highlightMock}
-      />
+      />,
+      { wishlistProviderProps }
     )
 
     expect(screen.queryByText(/population zero/i)).not.toBeInTheDocument()

--- a/src/templates/Wishlist/index.tsx
+++ b/src/templates/Wishlist/index.tsx
@@ -1,5 +1,7 @@
 import Base from 'templates/Base'
 
+import { useWishlist } from 'hooks/use-wishlist'
+
 import Heading from 'components/Heading'
 import Showcase from 'components/Showcase'
 import GameCard, { GameCardProps } from 'components/GameCard'
@@ -8,49 +10,58 @@ import { Divider } from 'components/Divider'
 import { Grid } from 'components/Grid'
 import { HighlightProps } from 'components/Highlight'
 import Empty from 'components/Empty'
+import Loader from 'components/Loader'
+
+import * as S from './styles'
 
 export type WhishlistTemplateProps = {
-  games?: GameCardProps[]
   recommendedTitle: string
   recommendedGames: GameCardProps[]
   recommendedHighlight: HighlightProps
 }
 
 const Wishlist = ({
-  games,
   recommendedTitle,
   recommendedGames,
   recommendedHighlight
-}: WhishlistTemplateProps) => (
-  <Base>
-    <Container>
-      <Heading lineLeft lineColor="secondary">
-        Wishlist
-      </Heading>
+}: WhishlistTemplateProps) => {
+  const { items, loading } = useWishlist()
 
-      {games && games.length >= 1 ? (
-        <Grid>
-          {games.map((game, index) => (
-            <GameCard key={`wishlist-${index}`} {...game} />
-          ))}
-        </Grid>
-      ) : (
-        <Empty
-          title="Your wishlist is empty"
-          description="The games added to your wishlist will be shown here"
-          hasLink
-        />
-      )}
+  return (
+    <Base>
+      <Container>
+        <Heading lineLeft lineColor="secondary">
+          Wishlist
+        </Heading>
 
-      <Divider />
-    </Container>
+        {loading ? (
+          <S.Loading>
+            <Loader />
+          </S.Loading>
+        ) : items.length >= 1 ? (
+          <Grid>
+            {items.map((game, index) => (
+              <GameCard key={`wishlist-${index}`} {...game} />
+            ))}
+          </Grid>
+        ) : (
+          <Empty
+            title="Your wishlist is empty"
+            description="The games added to your wishlist will be shown here"
+            hasLink
+          />
+        )}
 
-    <Showcase
-      title={recommendedTitle}
-      games={recommendedGames}
-      highlight={recommendedHighlight}
-    />
-  </Base>
-)
+        <Divider />
+      </Container>
+
+      <Showcase
+        title={recommendedTitle}
+        games={recommendedGames}
+        highlight={recommendedHighlight}
+      />
+    </Base>
+  )
+}
 
 export default Wishlist

--- a/src/templates/Wishlist/styles.ts
+++ b/src/templates/Wishlist/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+
+export const Loading = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40rem;
+
+  svg {
+    height: 10rem;
+    width: 10rem;
+  }
+`

--- a/src/utils/apolloCache.ts
+++ b/src/utils/apolloCache.ts
@@ -7,6 +7,15 @@ export default new InMemoryCache({
       fields: {
         games: concatPagination(['where', 'sort'])
       }
+    },
+    Wishlist: {
+      fields: {
+        games: {
+          merge(_, incoming) {
+            return incoming
+          }
+        }
+      }
     }
   }
 })


### PR DESCRIPTION
Configured apollo client to cache Wishlist games.
Added a loading when adding/removing games.
Fixed broken tests.